### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -179,7 +179,7 @@ CreateTargets = function()
                     icon = info.target.icon,
                     currentZone = zone,
                     canInteract = function(entity, distance, coords, name, bone)
-                        if not _G.IsBusy and _G.InZone and CanPick(name) and _G.CurrentZone == zone and (info.job and PlayerJob.name == info.job) then return true end
+                        if not _G.IsBusy and _G.InZone and CanPick(name) and _G.CurrentZone == zone and (not info.job or PlayerJob.name == info.job) then return true end
                         return false
                     end,
                     onSelect = function(data)


### PR DESCRIPTION
Fixed job check logic in tree interaction script

- Updated the job check condition in the `canInteract` function to correctly handle cases where no specific job is required.
- The new logic ensures that interaction is allowed if `info.job` is `nil` or `false`, or if the player's job matches the required job.

This fix resolves the issue where players could not interact with tree boxes when no specific job was required.